### PR TITLE
Updated security context for volume mount permissions

### DIFF
--- a/kubernetes/deployment-drupal.yaml
+++ b/kubernetes/deployment-drupal.yaml
@@ -113,7 +113,10 @@ spec:
           name: files-public
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        fsGroup: 82
+        runAsUser: 82
+        runAsGroup: 82
       terminationGracePeriodSeconds: 30
       volumes:
       - configMap:


### PR DESCRIPTION
This will allow the filesystem to mount as www-data instead of root, which will solve our Drupal write permission problem